### PR TITLE
Added dependency on robotiq_85_msgs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,13 @@ project(robotiq_85_gripper_actions)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS actionlib rail_manipulation_msgs roscpp)
+find_package(catkin REQUIRED
+  COMPONENTS
+  actionlib
+  rail_manipulation_msgs
+  robotiq_85_msgs
+  roscpp
+)
 
 ###################################################
 ## Declare things to be passed to other projects ##

--- a/package.xml
+++ b/package.xml
@@ -19,9 +19,11 @@
   <build_depend>control_msgs</build_depend>
   <build_depend>rail_manipulation_msgs</build_depend>
   <build_depend>roscpp</build_depend>
+  <build_depend>robotiq_85_msgs</build_depend>
 
   <run_depend>actionlib</run_depend>
   <run_depend>control_msgs</run_depend>
   <run_depend>rail_manipulation_msgs</run_depend>
   <run_depend>roscpp</run_depend>
+  <run_depend>robotiq_85_msgs</run_depend>
 </package>


### PR DESCRIPTION
This package already implicitly depends on `robotiq_85_msgs`, but the dependencies aren't in the CMakeLists.txt or package.xml as they should be. The current setup makes it harder to debug the errors that arise.